### PR TITLE
Use instant rdsosmetrics_diskIO_util rather than max_over_time

### DIFF
--- a/alerts/Disk_IO_Utilization.json5
+++ b/alerts/Disk_IO_Utilization.json5
@@ -24,7 +24,7 @@ avg by (device) ( \n\
   or \n\
   irate(node_disk_io_time_seconds_total{instance=~\"{{ .Instance }}\"}[5m]) \n\
   or \n\
-  max_over_time(rdsosmetrics_diskIO_util{instance=~\"{{ .Instance }}\"}[5m]) / 100 \n\
+  rdsosmetrics_diskIO_util{instance=~\"{{ .Instance }}\"} / 100 \n\
 ) \n\
 ",
         "hide": false,

--- a/dashboards/Disk_Performance.json5
+++ b/dashboards/Disk_Performance.json5
@@ -912,11 +912,7 @@ rate(node_disk_io_time_seconds_total{device=~\"$device\", instance=~\"$host\"}[$
 or \n\
 irate(node_disk_io_time_seconds_total{device=~\"$device\", instance=~\"$host\"}[5m]) \n\
 or \n\
-( \n\
-  max_over_time(rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"}[$interval]) \n\
-  or \n\
-  max_over_time(rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"}[5m]) \n\
-) / 100 \n\
+rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"} / 100 \n\
 ",
             "format": "time_series",
             "hide": false,

--- a/dashboards/Health_Check.json5
+++ b/dashboards/Health_Check.json5
@@ -357,11 +357,7 @@ rate(node_disk_io_time_seconds_total{device=~\"$device\", instance=~\"$host\"}[5
 or \n\
 irate(node_disk_io_time_seconds_total{device=~\"$device\", instance=~\"$host\"}[5m]) \n\
 or \n\
-( \n\
-  max_over_time(rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"}[$interval]) \n\
-  or \n\
-  max_over_time(rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"}[5m]) \n\
-) / 100 \n\
+rdsosmetrics_diskIO_util{device=~\"$device\", instance=~\"$host\"} / 100 \n\
 ",
           "format": "time_series",
           "hide": false,

--- a/dashboards/MySQL_InnoDB_Metrics.json5
+++ b/dashboards/MySQL_InnoDB_Metrics.json5
@@ -2906,11 +2906,7 @@ rate(node_disk_io_time_seconds_total{instance=~\"$host\"}[$interval]) \n\
 or \n\
 irate(node_disk_io_time_seconds_total{instance=~\"$host\"}[5m]) \n\
 or \n\
-( \n\
-  max_over_time(rdsosmetrics_diskIO_util{instance=~\"$host\"}[$interval]) \n\
-  or \n\
-  max_over_time(rdsosmetrics_diskIO_util{instance=~\"$host\"}[5m]) \n\
-) / 100 \n\
+rdsosmetrics_diskIO_util{instance=~\"$host\"} / 100 \n\
 ",
             "format": "time_series",
             "hide": false,


### PR DESCRIPTION
It's a fix for the problem described in https://github.com/shatteredsilicon/ssm-submodules/issues/426#issuecomment-2859442587